### PR TITLE
Chip Input List

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -162,9 +162,9 @@
       }
     },
     "@suankularb-components/css": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@suankularb-components/css/-/css-2.4.0.tgz",
-      "integrity": "sha512-X98lVDZVSTIqAci6FmQiGzooLdBcwFrVBoowKtu8++TO7GQwXNI/aIPc+tuzhvYmL/bz1gAPIVRmQXszhSlI7Q==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@suankularb-components/css/-/css-2.4.1.tgz",
+      "integrity": "sha512-Cq7PGXnhlByGbn8bueo/NHLfEbyGMh8FzKGaOVW6r/YegM5BVPlEfqeawidtKj9P5fqOkQxe6NNADVlQFvOdJA==",
       "requires": {
         "sass": "^1.49.0"
       }
@@ -1462,9 +1462,9 @@
       "dev": true
     },
     "sass": {
-      "version": "1.49.9",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.49.9.tgz",
-      "integrity": "sha512-YlYWkkHP9fbwaFRZQRXgDi3mXZShslVmmo+FVK3kHLUELHHEYrCmL1x6IUjC7wLS6VuJSAFXRQS/DxdsC4xL1A==",
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.50.0.tgz",
+      "integrity": "sha512-cLsD6MEZ5URXHStxApajEh7gW189kkjn4Rc8DQweMyF+o5HF5nfEz8QYLMlPsTOD88DknatTmBWkOcw5/LnJLQ==",
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/suankularb-wittayalai-school/react-sk-components#readme",
   "dependencies": {
-    "@suankularb-components/css": "^2.4.0",
+    "@suankularb-components/css": "^2.4.1",
     "framer-motion": "^6.2.8",
     "react-hotkeys-hook": "^3.4.4"
   },

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -59,9 +59,7 @@ const Button = ({
     style={style}
     type={attr?.type}
     value={attr?.value}
-    onClick={() => {
-      if (onClick) onClick();
-    }}
+    onClick={() => onClick && onClick()}
   >
     {icon}
     {name && <span>{name}</span>}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -2,8 +2,8 @@
 import { SKComponent } from "../../utils/types";
 
 export interface ButtonProps extends SKComponent {
-  name?: string | JSX.Element;
-  label?: string;
+  name?: string;
+  label?: string | JSX.Element;
   type: "filled" | "outlined" | "text" | "tonal";
   iconOnly?: boolean;
   icon?: JSX.Element;
@@ -35,7 +35,7 @@ const Button = ({
   attr,
 }: ButtonProps) => (
   <button
-    aria-label={label}
+    aria-label={name}
     autoFocus={attr?.autoFocus}
     className={`${
       type == "outlined"
@@ -62,7 +62,7 @@ const Button = ({
     onClick={() => onClick && onClick()}
   >
     {icon}
-    {name && <span>{name}</span>}
+    {label && <span>{label}</span>}
   </button>
 );
 

--- a/src/components/Chip/ActionChip.tsx
+++ b/src/components/Chip/ActionChip.tsx
@@ -1,0 +1,44 @@
+// Types
+import { SKComponent } from "../../utils/types";
+
+export interface ActionChipProps extends SKComponent {
+  name: string;
+  type: "filled" | "tonal";
+  icon: JSX.Element;
+  onClick?: Function;
+  attr?: React.ButtonHTMLAttributes<HTMLButtonElement>;
+}
+
+const ActionChip = ({
+  name,
+  type,
+  icon,
+  onClick,
+  attr,
+  className,
+  style,
+}: ActionChipProps): JSX.Element => (
+  <button
+    aria-label={name}
+    autoFocus={attr?.autoFocus}
+    className={`${type == "filled" ? "btn-chip--filled" : "btn-chip"} ${
+      className || ""
+    }`}
+    disabled={attr?.disabled}
+    form={attr?.form}
+    formAction={attr?.formAction}
+    formEncType={attr?.formEncType}
+    formMethod={attr?.formMethod}
+    formNoValidate={attr?.formNoValidate}
+    formTarget={attr?.formTarget}
+    name={attr?.name}
+    style={style}
+    type={attr?.type}
+    value={attr?.value}
+    onClick={() => onClick && onClick()}
+  >
+    <div className="chip__icon">{icon}</div>
+  </button>
+);
+
+export default ActionChip;

--- a/src/components/Chip/ActionChip.tsx
+++ b/src/components/Chip/ActionChip.tsx
@@ -2,8 +2,8 @@
 import { SKComponent } from "../../utils/types";
 
 export interface ActionChipProps extends SKComponent {
-  name: string;
-  type: "filled" | "tonal";
+  name?: string;
+  type?: "filled" | "tonal";
   icon: JSX.Element;
   onClick?: Function;
   attr?: React.ButtonHTMLAttributes<HTMLButtonElement>;

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -55,7 +55,7 @@ const Chip = ({
   >
     {avatar && <div className="chip__avatar">{avatar}</div>}
     {leadingIcon && <div className="chip__icon">{leadingIcon}</div>}
-    <span>{name}</span>
+    {typeof name == "string" ? <span>{name}</span> : name}
     {trailingIcon && <div className="chip__icon">{trailingIcon}</div>}
   </button>
 );

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -33,7 +33,7 @@ const Chip = ({
   style,
 }: ChipProps): JSX.Element => (
   <button
-    className={` ${
+    className={`${
       leadingIcon && trailingIcon
         ? "chip--has-icons"
         : avatar && trailingIcon

--- a/src/components/Chip/InputChip.tsx
+++ b/src/components/Chip/InputChip.tsx
@@ -1,5 +1,16 @@
+// Components
+import MaterialIcon from "../Icon/MaterialIcon";
+
 // Types
-import { ChipProps } from "./Chip";
+import { SKComponent } from "../../utils/types";
+
+export interface InputChipProps extends SKComponent {
+  name: string | JSX.Element;
+  appearance?: "regular" | "elevated";
+  leadingIcon?: JSX.Element;
+  avatar?: JSX.Element;
+  onClose?: Function;
+}
 
 /**
  * A Chip that can be toggled on and off
@@ -12,11 +23,12 @@ import { ChipProps } from "./Chip";
 const InputChip = ({
   name,
   appearance,
-  avatar,
   leadingIcon,
+  avatar,
+  onClose,
   className,
   style,
-}: ChipProps) => {
+}: InputChipProps) => {
   return (
     <li
       className={`input-chip ${
@@ -31,6 +43,9 @@ const InputChip = ({
       {avatar && <div className="chip__avatar">{avatar}</div>}
       {leadingIcon && <div className="chip__icon">{leadingIcon}</div>}
       <span>{name}</span>
+      <button className="chip__icon--btn" onClick={() => onClose && onClose()}>
+        <MaterialIcon icon="close" />
+      </button>
     </li>
   );
 };

--- a/src/components/Chip/InputChip.tsx
+++ b/src/components/Chip/InputChip.tsx
@@ -42,7 +42,7 @@ const InputChip = ({
     >
       {avatar && <div className="chip__avatar">{avatar}</div>}
       {leadingIcon && <div className="chip__icon">{leadingIcon}</div>}
-      <span>{name}</span>
+      {typeof name == "string" ? <span>{name}</span> : name}
       <button className="chip__icon--btn" onClick={() => onClose && onClose()}>
         <MaterialIcon icon="close" />
       </button>

--- a/src/components/Chip/InputChip.tsx
+++ b/src/components/Chip/InputChip.tsx
@@ -30,7 +30,11 @@ const InputChip = ({
 }: InputChipProps) => (
   <li
     className={`input-chip ${
-      leadingIcon ? "chip--has-leading-icon" : avatar ? "chip--has-avatar" : ""
+      leadingIcon
+        ? "chip--has-icons"
+        : avatar
+        ? "chip--has-avatar-and-icon"
+        : "chip--has-trailing-icon"
     } ${appearance == "elevated" ? "chip--elevated" : ""} ${className || ""}`}
     style={style}
   >

--- a/src/components/Chip/InputChip.tsx
+++ b/src/components/Chip/InputChip.tsx
@@ -16,7 +16,6 @@ export interface InputChipProps extends SKComponent {
  * A Chip that can be toggled on and off
  * @param name The text to display inside the Chip
  * @param appearance How the Chip looks, can be either "regular" (default) or "elevated"
- * @param selected The default state of this Chip
  * @param avatar A circular image leading the Chip
  * @param leadingIcon The Icon to the left of the Chip
  */
@@ -28,26 +27,20 @@ const InputChip = ({
   onClose,
   className,
   style,
-}: InputChipProps) => {
-  return (
-    <li
-      className={`input-chip ${
-        leadingIcon
-          ? "chip--has-leading-icon"
-          : avatar
-          ? "chip--has-avatar"
-          : ""
-      } ${appearance == "elevated" ? "chip--elevated" : ""} ${className || ""}`}
-      style={style}
-    >
-      {avatar && <div className="chip__avatar">{avatar}</div>}
-      {leadingIcon && <div className="chip__icon">{leadingIcon}</div>}
-      {typeof name == "string" ? <span>{name}</span> : name}
-      <button className="chip__icon--btn" onClick={() => onClose && onClose()}>
-        <MaterialIcon icon="close" />
-      </button>
-    </li>
-  );
-};
+}: InputChipProps) => (
+  <li
+    className={`input-chip ${
+      leadingIcon ? "chip--has-leading-icon" : avatar ? "chip--has-avatar" : ""
+    } ${appearance == "elevated" ? "chip--elevated" : ""} ${className || ""}`}
+    style={style}
+  >
+    {avatar && <div className="chip__avatar">{avatar}</div>}
+    {leadingIcon && <div className="chip__icon">{leadingIcon}</div>}
+    {typeof name == "string" ? <span>{name}</span> : name}
+    <button className="chip__icon--btn" onClick={() => onClose && onClose()}>
+      <MaterialIcon icon="close" />
+    </button>
+  </li>
+);
 
 export default InputChip;

--- a/src/components/Chip/InputChip.tsx
+++ b/src/components/Chip/InputChip.tsx
@@ -1,0 +1,38 @@
+// Types
+import { ChipProps } from "./Chip";
+
+/**
+ * A Chip that can be toggled on and off
+ * @param name The text to display inside the Chip
+ * @param appearance How the Chip looks, can be either "regular" (default) or "elevated"
+ * @param selected The default state of this Chip
+ * @param avatar A circular image leading the Chip
+ * @param leadingIcon The Icon to the left of the Chip
+ */
+const InputChip = ({
+  name,
+  appearance,
+  avatar,
+  leadingIcon,
+  className,
+  style,
+}: ChipProps) => {
+  return (
+    <li
+      className={`input-chip ${
+        leadingIcon
+          ? "chip--has-leading-icon"
+          : avatar
+          ? "chip--has-avatar"
+          : ""
+      } ${appearance == "elevated" ? "chip--elevated" : ""} ${className || ""}`}
+      style={style}
+    >
+      {avatar && <div className="chip__avatar">{avatar}</div>}
+      {leadingIcon && <div className="chip__icon">{leadingIcon}</div>}
+      <span>{name}</span>
+    </li>
+  );
+};
+
+export default InputChip;

--- a/src/components/Chip/index.ts
+++ b/src/components/Chip/index.ts
@@ -1,2 +1,4 @@
 export { default } from "./Chip";
+export { default as ActionChip } from "./ActionChip";
 export { default as FilterChip } from "./FilterChip";
+export { default as InputChip } from "./InputChip";

--- a/src/components/ChipList/ChipInputList.tsx
+++ b/src/components/ChipList/ChipInputList.tsx
@@ -1,6 +1,8 @@
 // Components
+import ActionChip from "../Chip/ActionChip";
 import InputChip from "../Chip/InputChip";
 import ChipList from "./ChipList";
+import MaterialIcon from "../Icon/MaterialIcon";
 
 export interface ListItem {
   id: string;
@@ -12,20 +14,26 @@ export interface ListItem {
 export interface ChipInputListProps {
   list: Array<ListItem>;
   onChange?: (newList: Array<ListItem>) => void;
+  onAdd?: Function;
+  addChipName?: string;
   scrollable?: boolean;
   noWrap?: boolean;
 }
 
 /**
- * A list of Filter Chips and Chip Radio Groups that the user can choose many from
- * @param list An array of choices the user has entered
- * @param setList Set the state of the list
+ * A list of Chips added by the user via an input
+ * @param list An array of Chip Input List Items the user has entered
+ * @param onChange Triggered when a Chip Input List Item is deleted
+ * @param onAdd Triggered when the Add Chip is
+ * @param addChipName Add Chip label for screenreaders
  * @param scrollable If true, Chip List will fill the width and scroll
  * @param noWrap Disables wrapping when the width is too small, is *not* needed if `scrollable` is true
  */
 const ChipInputList = ({
   list,
   onChange,
+  onAdd,
+  addChipName,
   scrollable,
   noWrap,
 }: ChipInputListProps): JSX.Element => (
@@ -41,6 +49,13 @@ const ChipInputList = ({
         }
       />
     ))}
+    {onAdd && (
+      <ActionChip
+        name={addChipName || "Add"}
+        icon={<MaterialIcon icon="add" />}
+        onClick={() => onAdd()}
+      />
+    )}
   </ChipList>
 );
 

--- a/src/components/ChipList/ChipInputList.tsx
+++ b/src/components/ChipList/ChipInputList.tsx
@@ -1,10 +1,6 @@
-// Modules
-import { useEffect, useState } from "react";
-
 // Components
-import Chip from "../Chip/Chip";
+import InputChip from "../Chip/InputChip";
 import ChipList from "./ChipList";
-import MaterialIcon from "../Icon/MaterialIcon";
 
 export interface ListItem {
   id: string;
@@ -15,7 +11,7 @@ export interface ListItem {
 
 export interface ChipInputListProps {
   list: Array<ListItem>;
-  onChange?: Function;
+  setList?: (newList: Array<ListItem>) => void;
   scrollable?: boolean;
   noWrap?: boolean;
 }
@@ -23,31 +19,29 @@ export interface ChipInputListProps {
 /**
  * A list of Filter Chips and Chip Radio Groups that the user can choose many from
  * @param list An array of choices the user has entered
- * @param onChange Triggered when the selected Chips change
+ * @param setList Set the state of the list
  * @param scrollable If true, Chip List will fill the width and scroll
  * @param noWrap Disables wrapping when the width is too small, is *not* needed if `scrollable` is true
  */
 const ChipInputList = ({
-  list: defaultList,
-  onChange,
+  list,
+  setList,
   scrollable,
   noWrap,
-}: ChipInputListProps): JSX.Element => {
-  const [list, setList] = useState<Array<ListItem>>(defaultList);
-
-  useEffect(() => onChange && onChange(list), [list]);
-
-  return (
-    <ChipList scrollable={scrollable} noWrap={noWrap}>
-      {list.map((listItem, index) => (
-        <Chip
-          key={index}
-          name={listItem.name}
-          trailingIcon={<MaterialIcon icon="close" />}
-        />
-      ))}
-    </ChipList>
-  );
-};
+}: ChipInputListProps): JSX.Element => (
+  <ChipList scrollable={scrollable} noWrap={noWrap}>
+    {list.map((listItem, index) => (
+      <InputChip
+        key={index}
+        name={listItem.name}
+        avatar={listItem.avatar}
+        leadingIcon={listItem.leadingIcon}
+        onClose={() =>
+          setList && setList(list.filter((item) => listItem.id != item.id))
+        }
+      />
+    ))}
+  </ChipList>
+);
 
 export default ChipInputList;

--- a/src/components/ChipList/ChipInputList.tsx
+++ b/src/components/ChipList/ChipInputList.tsx
@@ -11,7 +11,7 @@ export interface ListItem {
 
 export interface ChipInputListProps {
   list: Array<ListItem>;
-  setList?: (newList: Array<ListItem>) => void;
+  onChange?: (newList: Array<ListItem>) => void;
   scrollable?: boolean;
   noWrap?: boolean;
 }
@@ -25,7 +25,7 @@ export interface ChipInputListProps {
  */
 const ChipInputList = ({
   list,
-  setList,
+  onChange,
   scrollable,
   noWrap,
 }: ChipInputListProps): JSX.Element => (
@@ -37,7 +37,7 @@ const ChipInputList = ({
         avatar={listItem.avatar}
         leadingIcon={listItem.leadingIcon}
         onClose={() =>
-          setList && setList(list.filter((item) => listItem.id != item.id))
+          onChange && onChange(list.filter((item) => listItem.id != item.id))
         }
       />
     ))}

--- a/src/components/ChipList/ChipInputList.tsx
+++ b/src/components/ChipList/ChipInputList.tsx
@@ -4,6 +4,9 @@ import InputChip from "../Chip/InputChip";
 import ChipList from "./ChipList";
 import MaterialIcon from "../Icon/MaterialIcon";
 
+// Types
+import { SKComponent } from "../../utils/types";
+
 export interface ListItem {
   id: string;
   avatar?: JSX.Element;
@@ -15,7 +18,12 @@ export interface ChipInputListProps {
   list: Array<ListItem>;
   onChange?: (newList: Array<ListItem>) => void;
   onAdd?: Function;
-  addChipName?: string;
+  addChipOptions?: SKComponent & {
+    name?: string;
+    type?: "filled" | "tonal";
+    icon: JSX.Element;
+    attr?: React.ButtonHTMLAttributes<HTMLButtonElement>;
+  };
   scrollable?: boolean;
   noWrap?: boolean;
 }
@@ -33,7 +41,7 @@ const ChipInputList = ({
   list,
   onChange,
   onAdd,
-  addChipName,
+  addChipOptions,
   scrollable,
   noWrap,
 }: ChipInputListProps): JSX.Element => (
@@ -51,9 +59,13 @@ const ChipInputList = ({
     ))}
     {onAdd && (
       <ActionChip
-        name={addChipName || "Add"}
-        icon={<MaterialIcon icon="add" />}
+        name={addChipOptions?.name || "Add"}
+        type={addChipOptions?.type}
+        icon={addChipOptions?.icon || <MaterialIcon icon="add" />}
         onClick={() => onAdd()}
+        attr={addChipOptions?.attr}
+        className={addChipOptions?.className}
+        style={addChipOptions?.style}
       />
     )}
   </ChipList>

--- a/src/components/ChipList/ChipInputList.tsx
+++ b/src/components/ChipList/ChipInputList.tsx
@@ -1,0 +1,47 @@
+// Modules
+import { useEffect, useState } from "react";
+
+// Components
+import Chip from "../Chip/Chip";
+import ChipList from "./ChipList";
+import MaterialIcon from "../Icon/MaterialIcon";
+
+export interface Choice {
+  id: string;
+  name: string | JSX.Element;
+}
+
+export interface ChipFilterListProps {
+  list: Array<Choice>;
+  onChange?: Function;
+  scrollable?: boolean;
+  noWrap?: boolean;
+}
+
+/**
+ * A list of Filter Chips and Chip Radio Groups that the user can choose many from
+ * @param list An array of choices the user has entered
+ * @param onChange Triggered when the selected Chips change
+ * @param scrollable If true, Chip List will fill the width and scroll
+ * @param noWrap Disables wrapping when the width is too small, is *not* needed if `scrollable` is true
+ */
+const ChipInputList = ({
+  list,
+  onChange,
+  scrollable,
+  noWrap,
+}: ChipFilterListProps): JSX.Element => {
+  return (
+    <ChipList scrollable={scrollable} noWrap={noWrap}>
+      {list.map((listItem, index) => (
+        <Chip
+          key={index}
+          name={listItem.name}
+          trailingIcon={<MaterialIcon icon="close" />}
+        />
+      ))}
+    </ChipList>
+  );
+};
+
+export default ChipInputList;

--- a/src/components/ChipList/ChipInputList.tsx
+++ b/src/components/ChipList/ChipInputList.tsx
@@ -61,7 +61,7 @@ const ChipInputList = ({
       <ActionChip
         name={addChipOptions?.name || "Add"}
         type={addChipOptions?.type}
-        icon={addChipOptions?.icon || <MaterialIcon icon="add" />}
+        icon={addChipOptions?.icon || <MaterialIcon icon="add" allowCustomSize />}
         onClick={() => onAdd()}
         attr={addChipOptions?.attr}
         className={addChipOptions?.className}

--- a/src/components/ChipList/ChipInputList.tsx
+++ b/src/components/ChipList/ChipInputList.tsx
@@ -6,13 +6,15 @@ import Chip from "../Chip/Chip";
 import ChipList from "./ChipList";
 import MaterialIcon from "../Icon/MaterialIcon";
 
-export interface Choice {
+export interface ListItem {
   id: string;
+  avatar?: JSX.Element;
+  leadingIcon?: JSX.Element;
   name: string | JSX.Element;
 }
 
-export interface ChipFilterListProps {
-  list: Array<Choice>;
+export interface ChipInputListProps {
+  list: Array<ListItem>;
   onChange?: Function;
   scrollable?: boolean;
   noWrap?: boolean;
@@ -26,11 +28,15 @@ export interface ChipFilterListProps {
  * @param noWrap Disables wrapping when the width is too small, is *not* needed if `scrollable` is true
  */
 const ChipInputList = ({
-  list,
+  list: defaultList,
   onChange,
   scrollable,
   noWrap,
-}: ChipFilterListProps): JSX.Element => {
+}: ChipInputListProps): JSX.Element => {
+  const [list, setList] = useState<Array<ListItem>>(defaultList);
+
+  useEffect(() => onChange && onChange(list), [list]);
+
   return (
     <ChipList scrollable={scrollable} noWrap={noWrap}>
       {list.map((listItem, index) => (

--- a/src/components/ChipList/ChipInputList.tsx
+++ b/src/components/ChipList/ChipInputList.tsx
@@ -32,8 +32,8 @@ export interface ChipInputListProps {
  * A list of Chips added by the user via an input
  * @param list An array of Chip Input List Items the user has entered
  * @param onChange Triggered when a Chip Input List Item is deleted
- * @param onAdd Triggered when the Add Chip is
- * @param addChipName Add Chip label for screenreaders
+ * @param onAdd Triggered when Add Chip is
+ * @param addChipOptions Options for Add Chip; same as Action Chip
  * @param scrollable If true, Chip List will fill the width and scroll
  * @param noWrap Disables wrapping when the width is too small, is *not* needed if `scrollable` is true
  */

--- a/src/components/ChipList/index.ts
+++ b/src/components/ChipList/index.ts
@@ -1,3 +1,4 @@
 export { default } from "./ChipList";
 export { default as ChipFilterList } from "./ChipFilterList";
+export { default as ChipInputList } from "./ChipInputList";
 export { default as ChipRadioGroup } from "./ChipRadioGroup";

--- a/src/components/Dialog/DialogActions.tsx
+++ b/src/components/Dialog/DialogActions.tsx
@@ -33,7 +33,7 @@ const DialogActions = ({
       <Button
         key={action.name}
         type="text"
-        name={action.name}
+        label={action.name}
         className={action.isDangerous ? "btn--danger" : undefined}
         onClick={() =>
           action.type == "close"

--- a/src/components/Dialog/DialogHeader.tsx
+++ b/src/components/Dialog/DialogHeader.tsx
@@ -58,7 +58,7 @@ const DialogHeader = ({
         )}
         {onSubmit && (
           <Button
-            name={submitName || "Submit"}
+            label={submitName || "Submit"}
             type="text"
             onClick={() => onSubmit()}
           />

--- a/src/components/Input/KeyboardInput.tsx
+++ b/src/components/Input/KeyboardInput.tsx
@@ -8,8 +8,8 @@ export interface KeyboardInputProps extends SKComponent {
   name: string;
   type: "email" | "number" | "password" | "tel" | "text" | "url";
   label: string;
-  onChange: Function;
-  defaultValue?: string | number;
+  onChange: (newValue: string) => void;
+  defaultValue?: string;
   attr?: React.InputHTMLAttributes<HTMLInputElement>;
 }
 
@@ -40,7 +40,7 @@ const KeyboardInput = ({
   style,
   attr,
 }: KeyboardInputProps): JSX.Element => {
-  const [inputValue, setInputValue] = useState(defaultValue || "");
+  const [inputValue, setInputValue] = useState<string>(defaultValue || "");
 
   useEffect(() => onChange && onChange(inputValue), [inputValue]);
 

--- a/src/components/Input/TextArea.tsx
+++ b/src/components/Input/TextArea.tsx
@@ -7,8 +7,8 @@ import { SKComponent } from "../../utils/types";
 export interface TextAreaProps extends SKComponent {
   name: string;
   label: string;
-  onChange: Function;
-  defaultValue?: string | number;
+  onChange: (newValue: string) => void;
+  defaultValue?: string;
   attr?: React.TextareaHTMLAttributes<HTMLInputElement>;
 }
 
@@ -31,7 +31,7 @@ const TextArea = ({
   style,
   attr,
 }: TextAreaProps): JSX.Element => {
-  const [inputValue, setInputValue] = useState(defaultValue);
+  const [inputValue, setInputValue] = useState<string>(defaultValue || "");
 
   useEffect(() => onChange && onChange(inputValue), [inputValue]);
 

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -2,8 +2,8 @@
 import { SKComponent, LinkElement as LinkElementType } from "../../utils/types";
 
 export interface LinkProps extends SKComponent {
-  name?: string | JSX.Element;
-  label?: string;
+  name?: string;
+  label?: string | JSX.Element;
   type: "filled" | "outlined" | "text" | "tonal";
   iconOnly?: boolean;
   icon?: JSX.Element;
@@ -38,7 +38,7 @@ const LinkButton = ({
   LinkElement ? (
     <LinkElement href={url}>
       <a
-        aria-label={label}
+        aria-label={name}
         className={`${
           type == "outlined"
             ? "btn--outlined"
@@ -53,12 +53,12 @@ const LinkButton = ({
         style={style}
       >
         {icon}
-        {name && <span>{name}</span>}
+        {label && <span>{label}</span>}
       </a>
     </LinkElement>
   ) : (
     <a
-      aria-label={label}
+      aria-label={name}
       className={`${
         type == "outlined"
           ? "btn--outlined"
@@ -81,7 +81,7 @@ const LinkButton = ({
       referrerPolicy={attr?.referrerPolicy}
     >
       {icon}
-      {name && <span>{name}</span>}
+      {label && <span>{label}</span>}
     </a>
   );
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -6,7 +6,7 @@ export {
   CardSupportingText,
 } from "./Card";
 export { default as CardList } from "./CardList";
-export { default as Chip, FilterChip } from "./Chip";
+export { default as Chip, ActionChip, FilterChip, InputChip } from "./Chip";
 export {
   default as ChipList,
   ChipFilterList,

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -10,6 +10,7 @@ export { default as Chip, FilterChip } from "./Chip";
 export {
   default as ChipList,
   ChipFilterList,
+  ChipInputList,
   ChipRadioGroup,
 } from "./ChipList";
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export {
   FilterChip,
   ChipList,
   ChipFilterList,
+  ChipInputList,
   ChipRadioGroup,
   Dialog,
   DialogHeader,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/26425747/162152171-1f09416f-24d2-404a-8b95-ad171f00aa2e.png)

> _Attention, backwards compatibility lost_: the props `name` and `label` are now swapped on Button and Link Button.

**Features**
- Chip Input List
  Resolves #39

**Fixes**
- `name` and `label` on Button and Link Button should be swapped
